### PR TITLE
Editor only assambly compilation problem

### DIFF
--- a/Editor/Unity.SerializableGuid.Editor.asmdef
+++ b/Editor/Unity.SerializableGuid.Editor.asmdef
@@ -3,7 +3,9 @@
     "references": [
         "GUID:c85f41d4379abdb4eafe8f0f3fe7380b"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Assembly definitions that have editor only code should only be included on the editor.